### PR TITLE
Fix extensions/INTEL/SPV_INTEL_function_pointers/alias.ll for intel/llvm

### DIFF
--- a/llvm-spirv/test/extensions/INTEL/SPV_INTEL_function_pointers/alias.ll
+++ b/llvm-spirv/test/extensions/INTEL/SPV_INTEL_function_pointers/alias.ll
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: define spir_func i32 @foo(i32 %x)
 
-; CHECK-LLVM: define spir_kernel void @bar(ptr %y)
+; CHECK-LLVM: define spir_func void @bar(ptr %y)
 ; CHECK-LLVM: [[PTRTOINT:%.*]] = ptrtoint ptr @foo to i64
 ; CHECK-LLVM: store i64 [[PTRTOINT]], ptr %y, align 8
 
@@ -43,7 +43,7 @@ define spir_func i32 @foo(i32 %x) {
 
 @foo.alias = internal alias i32 (i32), i32 (i32)* @foo
 
-define spir_kernel void @bar(i64* %y) {
+define spir_func void @bar(i64* %y) {
   store i64 ptrtoint (i32 (i32)* @foo.alias to i64), i64* %y
   ret void
 }


### PR DESCRIPTION
The intel/llvm version of llvm-spirv generates entry points differently than upstream; based on my understanding, this is to work around an IGC bug. This causes a SPIR-V mismatch for the bar entry point in this testcase. bar doesn't need to be an entry point for the purposes of this test, so this change resolves this test failure in intel/llvm by making bar a normal function.